### PR TITLE
Use tmp file and variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Push notification from xcode on build complete using Pushbullet
 * Download the PushBullet app (https://www.pushbullet.com/apps) 
  * Create an account 
  * Under my account on the website create access token
- * Paste the access token in the end_time_script placeholder 
+ * Add `export PUSHBULLET_ACCESS_TOKEN="<your_access_token_here>"` to your bash profile
 
 * Enjoy your leisure compile time (https://xkcd.com/303/)
   

--- a/build_time_start.sh
+++ b/build_time_start.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-echo $(date +%s) > ../build_start_time
+echo $(date +%s) > /tmp/build_start_time

--- a/end_time_script.sh
+++ b/end_time_script.sh
@@ -4,7 +4,7 @@ END=$(date +%s)
 TOTAL=$(echo "($END - $START) / 60" | bc)
 
 if [ "$TOTAL" -ge 10 ]; then
-	curl --header 'Access-Token: <your_access_token_here>' \
+	curl --header "Access-Token: $PUSHBULLET_ACCESS_TOKEN" \
     --header 'Content-Type: application/json' \
     --data-binary '{"body":"Get back to work","title":"'"Done: $TOTAL minutes"'","type":"note"}' \
     --request POST \

--- a/end_time_script.sh
+++ b/end_time_script.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-START=$(cat ../build_start_time)
+#!/bin/bash
+START=$(cat /tmp/build_start_time)
 END=$(date +%s)
 TOTAL=$(echo "($END - $START) / 60" | bc)
 


### PR DESCRIPTION
Two changes:

1. Use `tmp` folder instead of the parent folder for writing the `build_start_time` file
1. Use a variable for the Pushbullet access token instead of hardcoding it into the script